### PR TITLE
Add multiple vectors to single record

### DIFF
--- a/jira_scraper/processors/vector_store.py
+++ b/jira_scraper/processors/vector_store.py
@@ -36,11 +36,17 @@ class QdrantVectorStoreManager(VectorStoreManager):
 
     def recreate_collection(self, collection_name: str, vector_size: int):
         """Recreate the collection with specified parameters."""
-        self.client.recreate_collection(
+        if self.client.collection_exists(collection_name):
+            self.client.delete_collection(collection_name)
+
+        self.client.create_collection(
             collection_name=collection_name,
             vectors_config=models.VectorParams(
                 size=vector_size,
-                distance=models.Distance.COSINE
+                distance=models.Distance.COSINE,
+                multivector_config=models.MultiVectorConfig(
+                    comparator=models.MultiVectorComparator.MAX_SIM,
+                )
             ),
         )
 


### PR DESCRIPTION
This commit changes the way how we store data in the vector database. Up until now, we stored the individual Jira chunks separately.

With this change, we are going to store the full Jira ticket together with multiple embeddings attached to it. Each embedding is computed per chunk.
