### PR TITLE
Allow setting of a temperature

### DIFF
--- a/evaluation/evaluation.py
+++ b/evaluation/evaluation.py
@@ -12,10 +12,12 @@ async def call_chatbot_api(client: httpx.AsyncClient,
                            url: str,
                            prompt: str,
                            similarity_threshold: float,
+                           temperature: float,
                            timeout: int):
     payload = {
         "content": prompt,
         "similarity_threshold": similarity_threshold,
+        "temperature": temperature,
     }
     try:
         response = await client.post(url,
@@ -74,6 +76,7 @@ async def process_row(client: httpx.AsyncClient,
                                  args.chatbot_api_url,
                                  row['user_prompt'],
                                  args.similarity_threshold,
+                                 temperature=args.temperature,
                                  timeout=args.chatbot_api_timeout)
 
     result = {
@@ -188,6 +191,14 @@ async def main_async():
         default=5,
         required=False,
         help="Maximum number of concurrent API calls"
+    )
+
+    parser.add_argument(
+        "--temperature" ,
+        type=float,
+        default=0,
+        required=False,
+        help="temperature value to be used by the model"
     )
 
     # Parse the arguments


### PR DESCRIPTION
This allows setting of temperature when communicating with the LLM. This can be used to ensure stable results when calculating the semantic similarity.