### PR TITLE
OSP doc scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Openstack documentation
+
+/openstack-docs-plaintext/
+.openstackvenv/
+osp_all_docs.pickle

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ pdm-lock-check: ## Check that the pdm.lock file is in a good shape
 tox: ## Run tox
 	tox
 
+install-openstack-docs-deps: ## Install dependencies for pulling openstack docs
+	python3.11 -m venv .openstackvenv && source .openstackvenv/bin/activate
+	pip install tox
+
+pull-openstack-docs: ## Pull and convert Openstack docs
+	./openstack_retriever/get_openstack_plaintext_docs.sh
+
 help: ## Show this help screen
 	@echo 'Usage: make <OPTIONS> ... <TARGETS>'
 	@echo ''

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ this repository contains:
 - `data_scraper`: a tool that scrapes jira issues and more to store the collected data
 in a vector database.
 - `feedback_exporter`: a tool to fetch user feedback from Chainlit DB and write it in to a Google Spreadsheet.
-
+- `openstack_retriever`: a tool to pull upstream openstack documentation (requires Python 3.11)
+- `osp_doc_scraper`: a tool for turning upstream OSP documentation into vector database. Requires documents retrieved by `openstack_retriever`.
 
 ## Getting Started
 

--- a/data_scraper/common/constants.py
+++ b/data_scraper/common/constants.py
@@ -1,6 +1,7 @@
 """Module for config constants."""
 
-COLLECTION_NAME = "rca-knowledge-base"
+JIRA_COLLECTION_NAME = "rca-knowledge-base"
+OSP_DOCS_COLLECTION_NAME = "rca-osp-docs-knowledge-base"
 DEFAULT_EMBEDDING_MODEL = "BAAI/bge-m3"
 DEFAULT_JIRA_URL = "https://issues.redhat.com"
 DEFAULT_JIRA_PROJECTS = {

--- a/data_scraper/core/scraper.py
+++ b/data_scraper/core/scraper.py
@@ -100,9 +100,10 @@ class Scraper:
             self.db_manager.recreate_collection(
                 self.config["db_collection_name"], vector_size
             )
-        elif not self.db_manager.check_collection(self.config["collection_name"]):
+        elif not self.db_manager.check_collection(self.config["db_collection_name"]):
             LOG.error(
-                "Requested database collection %s does not exist.", self.config["collection_name"])
+                "Requested database collection %s does not exist.",
+                self.config["db_collection_name"])
             raise IOError
 
         for record in tqdm(records, desc="Processing embeddings"):

--- a/data_scraper/main.py
+++ b/data_scraper/main.py
@@ -4,13 +4,13 @@ from datetime import datetime
 
 from argparse import ArgumentParser
 from data_scraper.common import constants
-from data_scraper.core.scraper import JiraScraper
+from data_scraper.core.scraper import JiraScraper, OSPDocScraper
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 
-def command():
+def data_scraper():
     """Entry point for command line execution."""
     parser = ArgumentParser("data_scraper")
 
@@ -33,7 +33,7 @@ def command():
     parser.add_argument("--jira_projects", nargs='+', type=str,
                         default=constants.DEFAULT_JIRA_PROJECTS)
     parser.add_argument("--db_collection_name", type=str,
-                        default=constants.COLLECTION_NAME)
+                        default=constants.JIRA_COLLECTION_NAME)
     parser.add_argument("--scraper-processes", type=int,
                         default=constants.DEFAULT_NUM_SCRAPER_PROCESSES)
     parser.add_argument("--date_cutoff", type=datetime.fromisoformat,
@@ -68,5 +68,43 @@ def command():
     scraper.run()
 
 
-if __name__ == "__main__":
-    command()
+def osp_doc_scraper():
+    """Entry point for command line execution."""
+    parser = ArgumentParser("osp_doc_scraper")
+
+    # Required arguments
+    parser.add_argument("--database_client_url", type=str, required=True)
+    parser.add_argument("--llm_server_url", type=str, required=True)
+    parser.add_argument("--llm_api_key", type=str, required=True)
+    parser.add_argument("--database_api_key", type=str, required=True)
+    parser.add_argument(
+        "--docs_location",
+        type=str,
+        help="Path to plaintext OSP docs generated with get_opentsack_plaintext_docs.sh",
+        required=True,
+        )
+
+    # Optional arguments
+    parser.add_argument("--chunk_size", type=int,
+                        default=constants.DEFAULT_CHUNK_SIZE)
+    parser.add_argument("--embedding_model", type=str,
+                        default=constants.DEFAULT_EMBEDDING_MODEL)
+    parser.add_argument("--db_collection_name", type=str,
+                        default=constants.OSP_DOCS_COLLECTION_NAME)
+    parser.add_argument("--osp_version", type=str, default="18.0")
+    args = parser.parse_args()
+
+    config_args = {
+        "database_client_url": args.database_client_url,
+        "llm_server_url": args.llm_server_url,
+        "llm_api_key": args.llm_api_key,
+        "database_api_key": args.database_api_key,
+        "chunk_size": args.chunk_size,
+        "embedding_model": args.embedding_model,
+        "db_collection_name": args.db_collection_name,
+        "docs_location": args.docs_location,
+        "osp_version": args.osp_version
+    }
+
+    scraper = OSPDocScraper(config_args)
+    scraper.run()

--- a/data_scraper/main.py
+++ b/data_scraper/main.py
@@ -92,6 +92,8 @@ def osp_doc_scraper():
     parser.add_argument("--db_collection_name", type=str,
                         default=constants.OSP_DOCS_COLLECTION_NAME)
     parser.add_argument("--osp_version", type=str, default="18.0")
+    parser.add_argument("--recreate_collection", type=bool, default=True,
+                        help="Recreate database collection from scratch.")
     args = parser.parse_args()
 
     config_args = {
@@ -103,7 +105,8 @@ def osp_doc_scraper():
         "embedding_model": args.embedding_model,
         "db_collection_name": args.db_collection_name,
         "docs_location": args.docs_location,
-        "osp_version": args.osp_version
+        "osp_version": args.osp_version,
+        "recreate_collection": args.recreate_collection,
     }
 
     scraper = OSPDocScraper(config_args)

--- a/data_scraper/processors/vector_store.py
+++ b/data_scraper/processors/vector_store.py
@@ -31,8 +31,8 @@ class VectorStoreManager(abc.ABC):
 class QdrantVectorStoreManager(VectorStoreManager):
     """Manages interactions with Qdrant database."""
 
-    def __init__(self, client_url: str, api_key: str):
-        self.client = QdrantClient(client_url, api_key=api_key)
+    def __init__(self, client_url: str, api_key: str, timeout=100):
+        self.client = QdrantClient(client_url, api_key=api_key, timeout=timeout)
 
     def recreate_collection(self, collection_name: str, vector_size: int):
         """Recreate the collection with specified parameters."""

--- a/openstack_retriever/get_openstack_plaintext_docs.sh
+++ b/openstack_retriever/get_openstack_plaintext_docs.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# Copyright 2025 Red Hat, Inc.
+# All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+set -eou pipefail
+
+# Check if 'tox' is available
+if ! command -v tox &> /dev/null; then
+  echo "Error: 'tox' is not installed, please install it before continuing." >&2
+  exit 1
+fi
+
+# The name of the output directory
+OUTPUT_DIR_NAME=${OUTPUT_DIR_NAME:-openstack-docs-plaintext}
+
+# OpenStack Version
+OS_VERSION=${OS_VERSION:-2024.2}
+
+# TODO(lucasagomes): Look into adding the "tacker" project. Document generation
+# for this project gets stuck in an infinite loop
+# List of OpenStack Projects
+_OS_PROJECTS="nova horizon keystone neutron cinder manila glance swift ceilometer \
+octavia designate heat placement ironic barbican aodh watcher adjutant blazar \
+cyborg magnum mistral skyline-apiserver skyline-console storlets \
+venus vitrage zun python-openstackclient tempest trove zaqar masakari"
+OS_PROJECTS=${OS_PROJECTS:-$_OS_PROJECTS}
+
+# Read the environment variable into an array
+IFS=' ' read -r -a os_projects <<< "$OS_PROJECTS"
+
+# Working directory
+WORKING_DIR="/tmp/os_docs_temp"
+
+# The current directory where the script was invoked
+CURR_DIR=$(pwd)
+
+# Maximum number of subprocess that should run in parallel
+NUM_WORKERS=${NUM_WORKERS:-$(nproc)}
+
+# Files containing logs from subprocesses
+declare -a LOG_FILES
+
+# Show content of log files stored in LOG_FILES.
+cat_log_files() {
+    for log_file in "${LOG_FILES[@]}"; do
+        echo "-- ${log_file} ---------------------------------------"
+        cat "${log_file}"
+        echo
+    done
+}
+
+# Show content of the log files stored in LOG_FILES and exit with non-zero
+# exit code.
+# Arguments:
+#   $1 - Error message that should be printed out to stderr
+# Usage:
+#   log_and_die "Sample error message"
+log_and_die() {
+    cat_log_files
+    echo "ERROR: $1" >&2
+    exit 1
+}
+
+# Clone repository from OpenDev and generate documentation in text format.
+# Arguments:
+#   $1 - Name of the OpenDev repository
+# Usage:
+#   generate_text_doc "nova"
+generate_text_doc() {
+    local project=$1
+    local _os_version=$2
+    local tox_text_docs_target="
+
+[testenv:text-docs]
+base_python = python3.11
+description =
+    Build documentation in text format.
+commands =
+  sphinx-build --keep-going -j auto -b text doc/source doc/build/text
+deps =
+  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/$_os_version}
+  -r{toxinidir}/doc/requirements.txt
+"
+
+    echo "Generating the plain-text documentation for OpenStack $project"
+    # Clone the project's repository, if not present
+    if [ ! -d "$project" ]; then
+        git clone https://opendev.org/openstack/"$project".git
+    fi
+
+    cd "$project"
+    if [ "$_os_version" != "master" ]; then
+        git switch stable/"$_os_version"
+        git pull origin stable/"$_os_version"
+    fi
+
+    # TODO(lpiwowar): Remove workarounds. Some of the documentations do not work with
+    # the feature of sphinx-build that allows generation of the docs in text format.
+    # List of issues:
+    #    * designate   = with custom ext.support_matrix extension the generation of the
+    #                    documentation gets stuck in infinite loop
+    #
+    #    * ironic      = with sphinxcontrib.apidoc extension the generation of the
+    #                    documentation gets stuck in infinite loop
+    #
+    #    * heat        = AttributeError: 'TextTranslator' object has no attribute '_classifier_count_in_li'
+    #                    when doc/source/template_guide documentation is present
+    #
+    #    * trove/zaqar = The doc/requirements.txt file does not install all deps required to
+    #                    generate the docs
+    #
+    if [ "$project" == "designate" ]; then
+        sed -i "/'ext\.support_matrix',/d" "doc/source/conf.py"
+    elif [ "$project" == "ironic" ]; then
+        sed -i "/'sphinxcontrib\.apidoc',/d" "doc/source/conf.py"
+    elif [ "$project" == "heat" ]; then
+        rm -rf doc/source/template_guide/
+    elif [[ "$project" == "trove" || "$project" == "zaqar" ]]; then
+        tox_text_docs_target+="  -r{toxinidir}/requirements.txt"
+    fi
+
+    if grep -q "text-docs" tox.ini; then
+        echo "The text-docs target exists for $project"
+        # Add additional actions here if needed
+    else
+        echo "The text-docs target does not exist for $project. Appending it..."
+        echo "$tox_text_docs_target" >> tox.ini
+    fi
+
+    # Generate the docs in plain-text
+    tox -etext-docs
+
+    # Copy documentation to project's output directory
+    local project_output_dir=$WORKING_DIR/openstack-docs-plaintext/$project
+    rm -rf "$project_output_dir"
+    mkdir -p "$project_output_dir"
+    cp -r doc/build/text "$project_output_dir"/"$OS_VERSION"
+
+    # Remove artifacts
+    rm -rf "$project_output_dir"/"$OS_VERSION"/{_static/,.doctrees/}
+
+    # Exit project's directory
+    cd -
+}
+
+mkdir -p $WORKING_DIR
+cd $WORKING_DIR
+echo "Working directory: $WORKING_DIR"
+
+for os_project in "${os_projects[@]}"; do
+    os_project_log_file=$(mktemp "${os_project}"_XXXXX.log)
+    LOG_FILES+=("${os_project_log_file}")
+
+    echo "Generating documentation for ${os_project}. [logs -> ${WORKING_DIR}/${os_project_log_file}]"
+    _os_version=$OS_VERSION
+    # The tempest project is branchless
+    if [ "${os_project}" == "tempest" ]; then
+        _os_version="master"
+    fi
+    generate_text_doc "$os_project" "$_os_version" > "${os_project_log_file}" 2>&1 &
+
+    num_running_subproc=$(jobs -r | wc -l)
+    if [ "${num_running_subproc}" -ge "${NUM_WORKERS}" ]; then
+        echo "Using ${num_running_subproc}/${NUM_WORKERS} workers. Waiting ..."
+        wait -n || log_and_die "Subprocess generating text documentation failed!"
+	echo "Using $(( --num_running_subproc ))/${NUM_WORKERS} workers."
+    fi
+done
+
+echo "Waiting for the last subprocess to finish the documentation generation."
+for subproc_pid in $(jobs -p); do
+    wait "${subproc_pid}" || log_and_die "Subprocess generating text documentation failed!"
+    echo "Using $(jobs -r | wc -l)/${NUM_WORKERS} workers."
+done
+cat_log_files
+
+rm -rf "$CURR_DIR"/openstack-docs-plaintext/*/"${OS_VERSION}"
+cp -r "$WORKING_DIR"/openstack-docs-plaintext "$CURR_DIR/$OUTPUT_DIR_NAME"
+
+# TODO(lucasagomes): Should we delete the working directory ?!
+echo "Done. Documents can be found at $CURR_DIR/$OUTPUT_DIR_NAME"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,10 @@ dev = [
 py-modules = []
 
 [project.scripts]
-data_scraper = "data_scraper.main:command"
+data_scraper = "data_scraper.main:data_scraper"
 feedback_exporter = "feedback_exporter.export_feedback:main"
 evaluation = "evaluation.evaluation:main"
+osp_doc_scraper = "data_scraper.main:osp_doc_scraper"
 
 [tool.setuptools.packages.find]
 include = ["data_scraper*", "feedback_exporter*"]


### PR DESCRIPTION
This pr introduces tooling for vectorization of upstream OSP docs. 

To facilitate this, the original scraper was refactored, so common code is used. Test collection, compile using the refactored jira scraper was pushed under designation `rca-knowledge-base-refactor`. 

The script for pulling upstream documentation requires different python version than our main tooling as noted in the proposed change to README. 

`OSPDocScraper` is still WIP. 