### PR TITLE
Change TEMPEST_TEST_PATTERN and allow record_id based on record field combination

### DIFF
--- a/data_scraper/core/ci_logs_scraper.py
+++ b/data_scraper/core/ci_logs_scraper.py
@@ -14,7 +14,7 @@ LOG.setLevel(logging.INFO)
 class CILogsRecord(TypedDict):
     """CILogs data point."""
     url: str
-    topic: str
+    test_name: str
     text: str
     components: list[str]
     kind: str
@@ -37,7 +37,7 @@ class CILogsScraper(Scraper):
         for document in documents:
             ci_logs_records.append({
                 "url": document["url"],
-                "topic": document["test_name"],
+                "test_name": document["test_name"],
                 "text": document["traceback"],
                 "components": [],
                 "kind": "zuul_jobs",

--- a/data_scraper/core/scraper.py
+++ b/data_scraper/core/scraper.py
@@ -113,6 +113,17 @@ class Scraper:
             combined_key = "_".join([record[field] for field in record_fields_for_key])
             record_id = str(uuid.uuid5(uuid.NAMESPACE_URL, combined_key))
             if not record['url']:
+                # Check if all required fields for the key are present
+                missing_fields = [
+                    field for field in record_fields_for_key
+                    if field not in record or not record[field]
+                ]
+                if missing_fields:
+                    LOG.error("Missing required fields for key generation: %s", missing_fields)
+                    continue
+
+                combined_key = "_".join([record[field] for field in record_fields_for_key])
+                record_id = str(uuid.uuid5(uuid.NAMESPACE_URL, combined_key))
                 LOG.error("Missing required URL field")
                 continue
 
@@ -151,7 +162,7 @@ class Scraper:
         """Convert raw data into list of dictionaries."""
         raise NotImplementedError
 
-    def run(self, record_fields_for_key=("url",)):
+    def run(self, record_fields_for_key: tuple[str,...] = ("url",)):
         """Main execution method."""
         documents = self.get_documents()
         if not documents:

--- a/data_scraper/core/scraper.py
+++ b/data_scraper/core/scraper.py
@@ -110,22 +110,16 @@ class Scraper:
             raise IOError
 
         for record in tqdm(records, desc="Processing embeddings"):
+            missing_fields = [
+                field for field in record_fields_for_key
+                if field not in record or not record[field]
+            ]
+            if missing_fields:
+                LOG.error("Missing required fields for key generation: %s", missing_fields)
+                continue
+
             combined_key = "_".join([record[field] for field in record_fields_for_key])
             record_id = str(uuid.uuid5(uuid.NAMESPACE_URL, combined_key))
-            if not record['url']:
-                # Check if all required fields for the key are present
-                missing_fields = [
-                    field for field in record_fields_for_key
-                    if field not in record or not record[field]
-                ]
-                if missing_fields:
-                    LOG.error("Missing required fields for key generation: %s", missing_fields)
-                    continue
-
-                combined_key = "_".join([record[field] for field in record_fields_for_key])
-                record_id = str(uuid.uuid5(uuid.NAMESPACE_URL, combined_key))
-                LOG.error("Missing required URL field")
-                continue
 
             chunks: list[str] = self.get_chunks(record)
 

--- a/data_scraper/main.py
+++ b/data_scraper/main.py
@@ -248,7 +248,7 @@ def ci_logs_scraper() -> None:
 
     # when json is ready, proceed with tracebacks and store them to QdrantDB
     scraper = CILogsScraper(config_args)
-    scraper.run()
+    scraper.run(("url", "test_name"))
 
 
 def solutions_scraper() -> None:

--- a/data_scraper/processors/ci_logs_provider.py
+++ b/data_scraper/processors/ci_logs_provider.py
@@ -36,8 +36,8 @@ CUTOFF_TIME = datetime.now() - timedelta(days=14)  # 2 weeks ago
 
 # Test path constants
 TEST_OPERATOR_PATH = "logs/controller-0/ci-framework-data/tests/test_operator"
-TEMPEST_TEST_PATTERN = "tempest-tests"
-TOBIKO_TEST_PATTERN = "tobiko-tests"
+TEMPEST_TEST_PATTERN = "tempest-"
+TOBIKO_TEST_PATTERN = "tobiko-"
 
 async def fetch_with_gssapi(url, params=None, timeout=30.0):
     """


### PR DESCRIPTION
1) Change TEMPEST_TEST_PATTERN to be less restrictive to accommodate with different path names in logs
2) Allow record_ids based on record field combination 

Fixes #51 
Fixes #53